### PR TITLE
Add contributing guidelines and implement CI/CD rollout

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+- What changed?
+- Why is this change needed?
+
+## Validation
+
+- [ ] `python build.py`
+- [ ] `python build.py --lint-shaders`
+- [ ] `python build.py --lint-shaders --strict-structure` (when applicable)
+- [ ] `python build-trim.py` (when applicable)
+
+## Scope Check
+
+- [ ] No manual edits under `out/` or `out-trim/`
+- [ ] Docs updated if behavior/workflow changed

--- a/.github/workflows/shader-lint.yml
+++ b/.github/workflows/shader-lint.yml
@@ -40,3 +40,23 @@ jobs:
 
       - name: Run build lint gate
         run: python build.py $BUILD_ARGS --jobs 1
+
+      - name: Build trimmed output
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: python build-trim.py
+
+      - name: Upload out artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/upload-artifact@v4
+        with:
+          name: scanline-classic-out
+          path: out/
+          retention-days: 14
+
+      - name: Upload out-trim artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/upload-artifact@v4
+        with:
+          name: scanline-classic-out-trim
+          path: out-trim/
+          retention-days: 14

--- a/.github/workflows/shader-lint.yml
+++ b/.github/workflows/shader-lint.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   build-lint-gate:
     runs-on: ubuntu-latest

--- a/.github/workflows/shader-lint.yml
+++ b/.github/workflows/shader-lint.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   build-lint-gate:
+    name: Build Lint Gate
     runs-on: ubuntu-latest
     env:
       BUILD_ARGS: "--lint-shaders"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,189 @@
+# Contributing Handbook
+
+Thank you for contributing to Scanline Classic.
+
+This repository is a **data-driven RetroArch shader/preset build system**. Contributions are expected to preserve deterministic generation, schema compatibility, and shader structure/lint quality.
+
+## 1) Repository model and source of truth
+
+Scanline Classic is generated from source inputs:
+
+- `presetdata/input/*.json` (+ nested folders)
+- `presetdata/pipelines/*.json`
+- `presetdata/params/*.json`
+- `shaders/*.slang` and `shaders/*.inc`
+- `scripts/*.py`
+
+Generated output folders are:
+
+- `out/`
+- `out-trim/`
+
+### Standard
+
+- Edit source-of-truth files only.
+- Do **not** manually edit files in `out/` or `out-trim/` except one-off debugging.
+
+## 2) Local environment
+
+### Required
+
+- Python 3.12 recommended (CI-aligned).
+- Dependencies:
+
+```bash
+python -m pip install -r external/presetgen/requirements.txt
+```
+
+### Optional
+
+- Local `.venv` at repo root. `build.py` will prefer `.venv/Scripts/python.exe` on Windows when present.
+
+## 3) Build and validation commands
+
+Run from repository root.
+
+### Core build
+
+```bash
+python build.py
+```
+
+### Build with lint gate
+
+```bash
+python build.py --lint-shaders
+```
+
+### Build with strict structure gate
+
+```bash
+python build.py --lint-shaders --strict-structure
+```
+
+### Shader lint only
+
+```bash
+python scripts/lint_shaders.py
+```
+
+### Strict shader lint only
+
+```bash
+python scripts/lint_shaders.py --strict-structure
+```
+
+### Trim distribution
+
+```bash
+python build-trim.py
+```
+
+## 4) CI expectations
+
+Current CI lint gate (`.github/workflows/shader-lint.yml`) runs:
+
+- Default: `python build.py --lint-shaders --jobs 1`
+- Strict for pushes to `master` and PRs targeting `master`:
+  - `python build.py --lint-shaders --strict-structure --jobs 1`
+
+### Standard
+
+Before requesting review, contributors should run the strict command locally for shader/pipeline/parameter changes.
+
+## 5) Preset data authoring standards
+
+## 5.1 Input presets (`presetdata/input`)
+
+Input presets should compose reusable pipeline and parameter JSON blocks.
+
+Minimum expected fields:
+
+- `filename`
+- `type`
+- `title`
+- `description`
+- `pipeline_root`
+- `pipelines`
+
+Commonly used fields:
+
+- `parameter_root`
+- `parameter_sets`
+- `parameter_overrides`
+
+Use existing category and naming patterns (`consumer`, `professional`, region/signal suffixes like `-rf`, `-composite`, `-svideo`) unless there is a clear design reason not to.
+
+## 5.2 Pipelines (`presetdata/pipelines`)
+
+Pipelines define pass wiring and texture/pass options.
+
+### Standard
+
+- Keep pipelines modular and reusable.
+- Prefer adding a new focused pipeline JSON over duplicating large pipeline blocks in multiple input presets.
+- Preserve output-stage wiring patterns where applicable (for example post-stage bezel integration in `misc/post.json`).
+
+## 5.3 Parameters (`presetdata/params`)
+
+Parameter sets are grouped by domain (`sys`, `disp`, `misc`) and should remain reusable.
+
+### Standard
+
+- Place new parameter sets in the closest existing domain/category.
+- Prefer shared parameter sets over large one-off override dictionaries in input presets.
+- Keep numeric defaults/ranges consistent with neighboring files and parameter intent.
+
+## 5.4 Schema compatibility
+
+All preset/pipeline/parameter JSON must remain compatible with PresetGen schemas under `external/presetgen`.
+
+## 6) Shader authoring standards
+
+When editing `shaders/*.slang` or `shaders/*.inc`, follow:
+
+- `doc/SHADER_AUTHORING_CHECKLIST.md`
+
+### Required lint/style behavior
+
+- Spaces only (no tabs)
+- No trailing whitespace
+- No excessive blank-line runs
+- K&R control-flow brace style
+- Valid stage flow and strict structure when applicable
+
+### Standard
+
+- Run `python scripts/lint_shaders.py` for touched shader/include files.
+- For structure-sensitive changes, run strict mode and build lint gate (`--strict-structure`).
+
+## 7) Packaging and trim standards
+
+If touching trim behavior, rules, or distribution composition:
+
+- Validate with `python build-trim.py`
+- Review `trim-rules.txt` impact and preserve documented exceptions
+
+## 8) Documentation standards
+
+If behavior, commands, or contributor workflow changes:
+
+- Update relevant docs in the same PR (for example `README.md`, `doc/SHADER_AUTHORING_CHECKLIST.md`, CI docs).
+
+## 9) Pull request standards
+
+Each PR should:
+
+- Be scoped to one coherent change.
+- Include a clear description of what changed and why.
+- Include local validation commands and outcomes.
+- Avoid unrelated refactors.
+- Keep generated-output churn out of commits unless explicitly requested by maintainers.
+
+## 10) Pre-merge checklist
+
+- [ ] Changes are in source-of-truth files (not manual edits under `out/` or `out-trim/`).
+- [ ] Relevant lint/build commands were run locally.
+- [ ] Strict structure checks were run when required.
+- [ ] `build-trim.py` was run when trim/packaging logic changed.
+- [ ] Documentation was updated when workflow or behavior changed.

--- a/doc/CI_CD_30_DAY_ROLLOUT.md
+++ b/doc/CI_CD_30_DAY_ROLLOUT.md
@@ -54,7 +54,7 @@ This document defines a practical 30-day roadmap for expanding CI/CD in Scanline
 - Require at least 1 approval
 - Dismiss stale approvals when new commits are pushed
 - Require status checks to pass before merging:
-  - `Build Lint Gate`
+  - `Build Lint Gate / Build Lint Gate`
 - Require branches to be up to date before merging
 - Restrict who can push to matching branches (or otherwise block direct pushes)
 - Optional but recommended: apply rule to administrators

--- a/doc/CI_CD_30_DAY_ROLLOUT.md
+++ b/doc/CI_CD_30_DAY_ROLLOUT.md
@@ -39,6 +39,26 @@ This document defines a practical 30-day roadmap for expanding CI/CD in Scanline
 - Every `master` push has downloadable artifacts.
 - No unreviewed merges to `master`.
 
+**Implementation Notes (2026-03-26)**
+- `.github/workflows/shader-lint.yml` now uploads both `out/` and `out-trim/` on successful pushes to `master`.
+- Current artifact names:
+  - `scanline-classic-out`
+  - `scanline-classic-out-trim`
+- Current retention:
+  - `retention-days: 14`
+- Practical caveat for the first exit criterion: artifacts are guaranteed for successful `master` CI runs; a failed run will not publish artifacts.
+
+**Branch Protection Checklist (GitHub Settings)**
+- Branch rule target: `master`
+- Require a pull request before merging
+- Require at least 1 approval
+- Dismiss stale approvals when new commits are pushed
+- Require status checks to pass before merging:
+  - `Build Lint Gate`
+- Require branches to be up to date before merging
+- Restrict who can push to matching branches (or otherwise block direct pushes)
+- Optional but recommended: apply rule to administrators
+
 ---
 
 ### Week 2: Nightly Full Validation
@@ -145,8 +165,8 @@ This document defines a practical 30-day roadmap for expanding CI/CD in Scanline
   - **Mitigation:** retention limits and selective artifact publishing.
 
 ## Immediate Next Actions
-1. Implement Week 1 artifact upload on `master` push.
-2. Enable branch protections with required Build Lint Gate status.
+1. Merge CI artifact workflow changes to `master` and verify both artifacts on the next successful `master` push.
+2. Enable/verify branch protections with required `Build Lint Gate` status.
 3. Scaffold nightly full-validation workflow.
 
 ## Reference Commands


### PR DESCRIPTION
This pull request introduces significant improvements to contributor documentation, continuous integration (CI) workflows, and pull request (PR) standards for the Scanline Classic project. It adds a comprehensive contributing guide, refines the PR template, enhances the CI pipeline to upload build artifacts, and updates documentation to reflect these workflow changes.

**Documentation and Standards:**

* Added a detailed `CONTRIBUTING.md` outlining repository model, build/validation commands, authoring standards, and PR/merge expectations.
* Updated the PR template (`.github/PULL_REQUEST_TEMPLATE.md`) to require clear summaries, validation steps, and scope checks for all contributions.

**CI/CD Pipeline Improvements:**

* Modified the `shader-lint.yml` workflow to:
  - Explicitly set `contents: read` permissions for improved security.
  - On successful pushes to `master`, build trimmed output and upload both `out/` and `out-trim/` as artifacts (`scanline-classic-out`, `scanline-classic-out-trim`) with a 14-day retention period.
* Updated the CI/CD rollout documentation (`doc/CI_CD_30_DAY_ROLLOUT.md`) to document artifact upload behavior, artifact names, retention, and branch protection requirements. [[1]](diffhunk://#diff-59571b2ce3e13d07940408d6bb86129ac2111184ebd3e3d6dd9981e3265dfe68R42-R61) [[2]](diffhunk://#diff-59571b2ce3e13d07940408d6bb86129ac2111184ebd3e3d6dd9981e3265dfe68L148-R169)